### PR TITLE
Fix sonarqube reporting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,11 +11,11 @@ buildNode {
 
     stage('Sonar scanner') {
       onPR {
-        sh 'yarn sonar-scanner -Dsonar.analysis.mode=preview -Dsonar.host.url=$SONARQUBE_URL'
+        make 'sonar-scan-pr', name: 'Sonar Scan'
       }
 
       onMaster {
-       sh 'yarn sonar-scanner -Dsonar.host.url=$SONARQUBE_URL'
+        make 'sonar-scan', name: 'Sonar Scan'
       }
     }
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ endef
 install test:
 	@$(call compose, run dev yarn $@)
 
+sonar-scan-pr:
+	@$(call compose, run dev yarn sonar-scanner -Dsonar.analysis.mode=preview -Dsonar.host.url=${SONARQUBE_URL})
+
+sonar-scan:
+	@$(call compose, run dev yarn sonar-scanner -Dsonar.host.url=${SONARQUBE_URL})
+
 clean:
 	@$(call compose, run dev rm -rf node_modules coverage .sonar .scannerwork)
 	@$(call compose, down)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   dev:
-    image: divorce/yarn
+    image: divorce/yarn:8
     environment:
       - NODE_ENV=dev
     volumes:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/div-service-auth-provider-client",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Client to obtain tokens for service to service calls",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
#### Change description

Ensure that sonar scanner is run inside the container straight
after testing and coverage collection

#### How is the change implemented?

sonar-scanner is now invoked from Makefile and is run inside the container

#### Work checklist

- [x] Commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added if needed
- [x] Tests have been updated / new tests has been added if needed