### PR TITLE
Remove npm publish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,28 +27,4 @@ node {
   } finally {
     sh 'rm -rf node_modules coverage .sonar .scannerwork'
   }
-
-  onPR {
-      def currentVersion = sh(
-        script: "cat package.json | grep -Po '\"version\": \"\\K[^\"]*'",
-        returnStdout: true
-      ).trim()
-
-    try {
-      def latestVersion = sh(
-        script: "npm view @hmcts/div-service-auth-provider-client version --registry https://artifactory.reform.hmcts.net/artifactory/api/npm/npm-local/",
-        returnStdout: true
-      ).trim()
-
-      if (currentVersion == latestVersion) {
-        error "Version needs to be bumped, ${latestVersion} already published"
-      }
-    } catch (error) {
-      // Ignore 404 error when not already published
-    }
-  }
-
-  onMaster {
-    sh 'npm publish --registry https://artifactory.reform.hmcts.net/artifactory/api/npm/npm-local/'
-  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/div-service-auth-provider-client",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Client to obtain tokens for service to service calls",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
Removed npm publish as its no longer part of the build process.
Instead releases can be done in Github and this version will be picked up by yarn install for package.json files.